### PR TITLE
Doc: Clarify prerequisites in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out.png
 offscreen
 offscreen.exe
 .vscode/
+build/

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ make
 
 * cmake
 * glfw3
-* OpenGL
-* Linux: libgbm
+* OpenGL, GLU
+* libgbm (Linux specific)
 
 **Linux (apt)**
 
 ```bash
-sudo apt install cmake libglfw3-dev libgl1-mesa-dev libegl1-mesa-dev libgbm-dev
+sudo apt install cmake libglfw3-dev libgl1-mesa-dev libegl1-mesa-dev libgbm-dev libglu1-mesa-dev
 ```
 
 ## Examples


### PR DESCRIPTION
- Moved GLU to the general prerequisites list.
- Marked libgbm as Linux-specific in the general list.
- Ensured platform-specific package names remain in install commands.